### PR TITLE
Add page "What's new?"

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,8 @@
 * [⚡️Home](/)
 * [👨‍💻Installation](installation.md)
 * [🚀Usage](usage.md)
+* 🎉What's new?
+    * [v2.2.0 (latest)](whats_new/v2_2_0.md)
 
 * ✅Checks
 	* [Duplicated Key](checks/duplicated_key.md)

--- a/docs/whats_new/v2_2_0.md
+++ b/docs/whats_new/v2_2_0.md
@@ -1,0 +1,101 @@
+# What's new in v2.2.0 (latest)?
+
+We have prepared for you an overview of the key changes that are included in this release.
+
+### 1. Fixing warnings 🔥 
+
+Previously, `dotenv-linter` could only find problems in `.env` files:
+
+```bash
+$ dotenv-linter
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+```
+
+Now, it can fix them right away with the new `--fix`/`-f` argument:
+
+```bash
+$ dotenv-linter --fix
+Original file was backed up to: ".env_1601378896"
+
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+
+All warnings are fixed. Total: 2
+```
+
+### 2. Making a backup 💪 
+
+Fixing warnings in .env files is cool, but just in case `dotenv-linter` create a backup for each file.
+
+But this can be disabled using the `--no-backup` argument:
+
+```bash
+$ dotenv-linter --fix --no-backup
+Original file was backed up to: ".env_1601378896"
+
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+
+All warnings are fixed. Total: 2
+```
+
+### 3. Support for control comments 🕹
+
+Previously, checks could be disabled globally using the `--skip`/`-s` argument:
+
+```bash
+$ dotenv-linter --skip UnorderedKey EndingBlankLine
+.env:2 DuplicatedKey: The FOO key is duplicated
+
+Found 1 problem
+```
+
+Now, `dotenv-linter` supports control comments that allow you to turn off checks for both the entire file and a specific line:
+
+```env
+# .env
+# At the beginning - it disables checks for the whole file
+# dotenv-linter:off DuplicatedKey, EndingBlankLine
+
+# dotenv-linter:off UnorderedKey (You can disable a check for only some lines)
+FOO=BAR
+BAR=FOO
+# dotenv-linter:on UnorderedKey (And enable it again)
+```
+
+### 4. Displaying the total number of problems 👀
+
+When checking several `.env` files, there was often not enough information about how many warnings were found in all files.
+
+We have added this information:
+
+```bash
+$ dotenv-linter
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+.env.test:1 LeadingCharacter: Invalid leading character detected
+
+Found 3 problems
+```
+ 
+We have also added the new argument `--quiet`/`-q` to disable this:
+
+```bash
+$ dotenv-linter --quiet
+.env:2 DuplicatedKey: The FOO key is duplicated
+.env:3 UnorderedKey: The BAR key should go before the FOO key
+.env.test:1 LeadingCharacter: Invalid leading character detected
+```
+
+### 5. Installing the latest version from the repository 🍺
+
+Added the ability to install the latest version from the repository via [Homebrew](https://brew.sh):
+
+```bash
+$ brew install --HEAD dotenv-linter/tap/dotenv-linter
+```
+
+These are all the key changes in the project that were included in the new v2.2.0 release.
+
+More information you can find in the changelog: [v2.2.0](https://github.com/dotenv-linter/dotenv-linter/releases/tag/v2.2.0)  


### PR DESCRIPTION
Close #3

I have created the new page "What's new?" for the next release v2.2.0 and written about:
- [x] Fixing warnings;
- [x] Making a backup and the `--no-backup` argument;
- [x] Control comments;
- [x] Displaying the total number of problems and the `--quiet` argument;
- [x] Installing the latest version from the repository via Homebrew.
 


