### PR TITLE
docs: upd examples with show linted files

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,8 +4,11 @@ By default, `dotenv-linter` checks all `.env` files in the current directory:
 
 ```bash
 $ dotenv-linter
+Checking .env
 .env:2 DuplicatedKey: The FOO key is duplicated
 .env:3 UnorderedKey: The BAR key should go before the FOO key
+
+Checking .env.test
 .env.test:1 LeadingCharacter: Invalid leading character detected
 
 Found 3 problems
@@ -15,8 +18,11 @@ To check another directory, just pass its path as an argument. The same approach
 
 ```bash
 $ dotenv-linter dir1 dir2/.my-env-file
+Checking dir1/env
 dir1/.env:1 LeadingCharacter: Invalid leading character detected
 dir1/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
+
+Checking dir2/.my-env-file
 dir2/.my-env-file:1 LowercaseKey: The bar key should be in uppercase
 
 Found 3 problems
@@ -26,6 +32,7 @@ If you need to exclude a file from check, you can use the argument `--exclude FI
 
 ```bash
 $ dotenv-linter --exclude .env.test
+Checking .env
 .env:2 DuplicatedKey: The FOO key is duplicated
 .env:3 UnorderedKey: The BAR key should go before the FOO key
 
@@ -36,7 +43,11 @@ If you need a recursive search inside directories (deeper than 1 level), you can
 
 ```bash
 $ dotenv-linter --recursive
+Checking .env
+Checking dir1/.env
 dir1/.env:2 DuplicatedKey: The FOO key is duplicated
+
+Checking dir2/subdir/.env
 dir2/subdir/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
 
 Found 2 problems
@@ -46,6 +57,7 @@ If you need to skip some checks, you can use the argument `--skip CHECK_NAME` or
 
 ```bash
 $ dotenv-linter --skip UnorderedKey EndingBlankLine
+Checking .env
 .env:2 DuplicatedKey: The FOO key is duplicated
 
 Found 1 problem
@@ -94,6 +106,7 @@ UnorderedKey
 
 ```bash
 $ dotenv-linter -f
+Fixing .env
 Original file was backed up to: ".env_1601378896"
 
 .env:2 DuplicatedKey: The BAR key is duplicated
@@ -106,6 +119,7 @@ By default, `--fix` creates backups of files. If you want to disable the backup 
 
 ```bash
 $ dotenv-linter -f --no-backup
+Fixing .env
 .env:2 DuplicatedKey: The BAR key is duplicated
 .env:3 LowercaseKey: The foo key should be in uppercase
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ To check another directory, just pass its path as an argument. The same approach
 
 ```bash
 $ dotenv-linter dir1 dir2/.my-env-file
-Checking dir1/env
+Checking dir1/.env
 dir1/.env:1 LeadingCharacter: Invalid leading character detected
 dir1/.env:3 IncorrectDelimiter: The FOO-BAR key has incorrect delimiter
 


### PR DESCRIPTION
Update output structure in usage examples: show `checked`/`fixed` files.

It's necessary after [this PR](https://github.com/dotenv-linter/dotenv-linter/pull/311)