### PR TITLE
add instructions for installing using nix

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,6 +40,14 @@ $ trizen -S dotenv-linter-bin
 $ trizen -S dotenv-linter-git
 ```
 
+#### NixOS / Nix
+
+```bash
+
+$ nix-env -iA nixpkgs.dotenv-linter
+
+```
+
 #### Windows / Scoop
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,9 +43,7 @@ $ trizen -S dotenv-linter-git
 #### NixOS / Nix
 
 ```bash
-
 $ nix-env -iA nixpkgs.dotenv-linter
-
 ```
 
 #### Windows / Scoop


### PR DESCRIPTION
Hey! :wave: I took the liberty to package dotenv-linter for nixpkgs and this PR adds the instructions for installing it using that
https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&query=dotenv-linter